### PR TITLE
[Enhancement] All episodes are marked as completed when adding an anime to the Completion collection

### DIFF
--- a/Sources/AnimeDetailFeature/AnimeDetailView.swift
+++ b/Sources/AnimeDetailFeature/AnimeDetailView.swift
@@ -729,10 +729,21 @@ extension AnimeDetailView {
                             animation: .easeInOut(duration: 0.15)
                         )
                     } label: {
-                        Text("Mark as Watched")
+                        Text("Mark as watched")
                     }
                 }
-
+                
+                if !(viewState.episodeStore?.almostFinished ?? false) {
+                    Button {
+                        viewState.send(
+                            .markAllEpisodesAsWatched,
+                            animation: .easeInOut(duration: 0.15)
+                        )
+                    } label: {
+                        Text("Mark all as watched")
+                    }
+                }
+                
                 if (viewState.episodeStore?.progress ?? 0) > 0 {
                     Button {
                         viewState.send(
@@ -743,7 +754,18 @@ extension AnimeDetailView {
                         Text("Unwatch")
                     }
                 }
-
+                
+                if (viewState.episodeStore?.progress ?? 0) > 0 {
+                    Button {
+                        viewState.send(
+                            .markAllEpisodeAsUnwatched,
+                            animation: .easeInOut(duration: 0.15)
+                        )
+                    } label: {
+                        Text("Mark all as unwatched")
+                    }
+                }
+                
                 if case .downloaded = viewState.downloadStatus {
                     Button {
                         viewState.send(.removeDownload(episode.number))


### PR DESCRIPTION
This PR is in response to this issue: https://github.com/AnimeNow-Team/AnimeNow/issues/45.
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of Changes: 

- Upon addition of an anime to the Completed collection, all its episodes will be automatically marked as watched.
- For ease of use, the feature of marking all episodes as watched or unwatched has been provided through the buttons "Mark all as watched" and "Mark all as unwatched".
- The "Mark all as unwatched" button serves as a contingency option in case the anime was mistakenly added to the Completed collection. To revert the change, the anime must be removed from the Completed collection and the "Mark all as unwatched" button must be clicked.

### Verification
![Marked all as watched demo](https://user-images.githubusercontent.com/65370736/216878526-a291e19f-e722-44cd-a121-60865e4a0502.gif)
