### PR TITLE
[Enhancement] Add a retry button when episodes did not load in.

### DIFF
--- a/Sources/APIClient/APIClient.swift
+++ b/Sources/APIClient/APIClient.swift
@@ -106,7 +106,7 @@ typealias Query = URLQueryItem
 extension Query {
     init(
         name: String,
-        _ value: some CustomStringConvertible
+        _ value: CustomStringConvertible
     ) {
         self.init(
             name: name,

--- a/Sources/AnimeClient/AnimeClient+Live.swift
+++ b/Sources/AnimeClient/AnimeClient+Live.swift
@@ -216,7 +216,9 @@ public extension AnimeClient {
                     .listProviders(of: .ANIME)
                 )
             )
-        }
+				} invalidateAnimeProvider: { animeId, providerName in
+						cachedStreamingProviders.removeValue(forKey: "\(animeId)-\(providerName)")
+				}
     }()
 }
 

--- a/Sources/AnimeClient/AnimeClient+Mock.swift
+++ b/Sources/AnimeClient/AnimeClient+Mock.swift
@@ -35,5 +35,5 @@ public extension AnimeClient {
         .init()
     } getAnimeProviders: {
         []
-    }
+		} invalidateAnimeProvider: { _, _ in }
 }

--- a/Sources/AnimeClient/AnimeClient.swift
+++ b/Sources/AnimeClient/AnimeClient.swift
@@ -26,6 +26,7 @@ public struct AnimeClient {
     public let getSources: @Sendable (String, EpisodeLink) async throws -> SourcesOptions
     public let getSkipTimes: @Sendable (Int, Int) async throws -> [SkipTime]
     public let getAnimeProviders: @Sendable () async throws -> [ProviderInfo]
+    public let invalidateAnimeProvider: @Sendable (Anime.ID, String) async -> Void
 }
 
 // MARK: AnimeClient.Error

--- a/Sources/AnimeClient/Test.swift
+++ b/Sources/AnimeClient/Test.swift
@@ -35,5 +35,5 @@ public extension AnimeClient {
         .init()
     } getAnimeProviders: {
         [.init(name: "First"), .init(name: "Second"), .init(name: "Third")]
-    }
+		} invalidateAnimeProvider: { _, _ in }
 }

--- a/Sources/AnimeDetailFeature/AnimeDetailView.swift
+++ b/Sources/AnimeDetailFeature/AnimeDetailView.swift
@@ -615,9 +615,21 @@ extension AnimeDetailView {
                             viewState.compact
                         )
                     } else {
-                        Text("No episodes available from this provider.")
-                            .padding()
-                            .frame(height: 100)
+												VStack {
+														Text("No episodes available from this provider.")
+																.padding()
+														Button(action: {
+																viewState.send(.stream(.retryEpisodeFetch))
+														}) {
+																Label("Retry", systemImage: "arrow.clockwise")
+														}
+														.buttonStyle(.plain)
+														.padding(.horizontal)
+														.padding(.vertical, 10)
+														.background(Color.gray.opacity(0.25))
+														.clipShape(Capsule())
+												}
+												.frame(height: 150)
                     }
                 } failedView: {
                     Text("There was an error retrieving episodes from this provider.")


### PR DESCRIPTION
Sometimes the app does not load in episodes from providers, even though they do exist, and requires restart to load episodes in. This invalidates the current provider and fetches them again.